### PR TITLE
Add fluid merkle rewards claim connector

### DIFF
--- a/contracts/mainnet/connectors/merkleDistributor/events.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/events.sol
@@ -7,7 +7,8 @@ contract Events {
         address fToken,
         uint256 cycle,
         bytes32[] merkleProof,
-        uint256 getId
+        uint256 rewardsClaimed,
+        uint256 setId
     );
 
     event LogClaimOnBehalf(
@@ -16,6 +17,7 @@ contract Events {
         address fToken,
         uint256 cycle,
         bytes32[] merkleProof,
-        uint256 getId
+        uint256 rewardsClaimed,
+        uint256 setId
     );
 }

--- a/contracts/mainnet/connectors/merkleDistributor/events.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/events.sol
@@ -1,0 +1,21 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+contract Events {
+    event LogClaim(
+        uint256 cumulativeAmount,
+        address fToken,
+        uint256 cycle,
+        bytes32[] merkleProof,
+        uint256 getId
+    );
+
+    event LogClaimOnBehalf(
+        address recipient_,
+        uint256 cumulativeAmount,
+        address fToken,
+        uint256 cycle,
+        bytes32[] merkleProof,
+        uint256 getId
+    );
+}

--- a/contracts/mainnet/connectors/merkleDistributor/interface.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/interface.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+interface IFluidMerkleDistributor {
+    function claim(
+        address recipient_,
+        uint256 cumulativeAmount_,
+        address fToken_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_
+    ) external;
+}

--- a/contracts/mainnet/connectors/merkleDistributor/main.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/main.sol
@@ -8,7 +8,7 @@ import {TokenInterface} from "../../common/interfaces.sol";
 
 abstract contract FluidMerkle is Basic, Events {
     IFluidMerkleDistributor internal constant MERKLE_DISTRIBUTOR =
-        IFluidMerkleDistributor(address(0));
+        IFluidMerkleDistributor(0x1d3D6d38Da24E9Ff3B17693f6971CAe62c3AA1DE);
 
     TokenInterface internal constant TOKEN =
         TokenInterface(0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb);

--- a/contracts/mainnet/connectors/merkleDistributor/main.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/main.sol
@@ -1,37 +1,59 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.2;
 
-import { Basic } from "../../common/basic.sol";
-import { Events } from "./events.sol";
-import { IFluidMerkleDistributor } from "./interface.sol";
+import {Basic} from "../../common/basic.sol";
+import {Events} from "./events.sol";
+import {IFluidMerkleDistributor} from "./interface.sol";
+import {TokenInterface} from "../../common/interfaces.sol";
 
 abstract contract FluidMerkle is Basic, Events {
+    IFluidMerkleDistributor internal constant MERKLE_DISTRIBUTOR =
+        IFluidMerkleDistributor(address(0));
 
-    address private constant MERKLE_DISTRIBUTOR = address(0);
-    
+    TokenInterface internal constant TOKEN =
+        TokenInterface(0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb);
+
     /**
      * @dev Claims rewards from Fluid merkle distributor contract
      * @param cumulativeAmount_ Total reward cumulated since reward inception.
      * @param fToken_ Address of fToken on which rewards are being distributed.
      * @param cycle_ Current epoch cycle.
      * @param merkleProof_ Merkle proof that validates this claim.
-     * @param getId_ Id to get the cumulative amount.
+     * @param setId_ Id to set the rewards received.
      */
     function claim(
         uint256 cumulativeAmount_,
         address fToken_,
         uint256 cycle_,
         bytes32[] calldata merkleProof_,
-        uint256 getId_
-    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
-        uint256 _amt = getUint(getId_, cumulativeAmount_);
+        uint256 setId_
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        uint256 rewardsBeforeBal_ = TOKEN.balanceOf(address(this));
 
-        IFluidMerkleDistributor distributorContract_ = IFluidMerkleDistributor(MERKLE_DISTRIBUTOR);
+        MERKLE_DISTRIBUTOR.claim(
+            address(this),
+            cumulativeAmount_,
+            fToken_,
+            cycle_,
+            merkleProof_
+        );
 
-        distributorContract_.claim(address(this), _amt, fToken_, cycle_, merkleProof_);
+        uint256 rewardsClaimed_ = TOKEN.balanceOf(address(this)) -
+            rewardsBeforeBal_;
 
-        _eventName = "LogClaim(uint256,address,uint256,bytes32[],uint256)";
-        _eventParam = abi.encode(_amt, fToken_, cycle_, merkleProof_, getId_);
+        _eventName = "LogClaim(uint256,address,uint256,bytes32[],uint256,uint256)";
+        _eventParam = abi.encode(
+            cumulativeAmount_,
+            fToken_,
+            cycle_,
+            merkleProof_,
+            rewardsClaimed_,
+            setId_
+        );
     }
 
     /**
@@ -40,24 +62,43 @@ abstract contract FluidMerkle is Basic, Events {
      * @param fToken_ Address of fToken on which rewards are being distributed.
      * @param cycle_ Current epoch cycle.
      * @param merkleProof_ Merkle proof that validates this claim.
-     * @param getId_ Id to get the cumulative amount.
-    */
+     * @param setId_ Id to set the rewards received.
+     */
     function claimOnBehalf(
         address recipient_,
         uint256 cumulativeAmount_,
         address fToken_,
         uint256 cycle_,
         bytes32[] calldata merkleProof_,
-        uint256 getId_
-    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
-        uint256 _amt = getUint(getId_, cumulativeAmount_);
+        uint256 setId_
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        uint256 rewardsBeforeBal_ = TOKEN.balanceOf(recipient_);
 
-        IFluidMerkleDistributor distributorContract_ = IFluidMerkleDistributor(MERKLE_DISTRIBUTOR);
+        MERKLE_DISTRIBUTOR.claim(
+            recipient_,
+            cumulativeAmount_,
+            fToken_,
+            cycle_,
+            merkleProof_
+        );
 
-        distributorContract_.claim(recipient_, _amt, fToken_, cycle_, merkleProof_);
+        uint256 rewardsClaimed_ = TOKEN.balanceOf(recipient_) -
+            rewardsBeforeBal_;
 
-        _eventName = "LogClaimOnBehalf(address,uint256,address,uint256,bytes32[],uint256)";
-        _eventParam = abi.encode(recipient_, _amt, fToken_, cycle_, merkleProof_, getId_);
+        _eventName = "LogClaimOnBehalf(address,uint256,address,uint256,bytes32[],uint256,uint256)";
+        _eventParam = abi.encode(
+            recipient_,
+            cumulativeAmount_,
+            fToken_,
+            cycle_,
+            merkleProof_,
+            rewardsClaimed_,
+            setId_
+        );
     }
 }
 

--- a/contracts/mainnet/connectors/merkleDistributor/main.sol
+++ b/contracts/mainnet/connectors/merkleDistributor/main.sol
@@ -1,0 +1,66 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+import { Basic } from "../../common/basic.sol";
+import { Events } from "./events.sol";
+import { IFluidMerkleDistributor } from "./interface.sol";
+
+abstract contract FluidMerkle is Basic, Events {
+
+    address private constant MERKLE_DISTRIBUTOR = address(0);
+    
+    /**
+     * @dev Claims rewards from Fluid merkle distributor contract
+     * @param cumulativeAmount_ Total reward cumulated since reward inception.
+     * @param fToken_ Address of fToken on which rewards are being distributed.
+     * @param cycle_ Current epoch cycle.
+     * @param merkleProof_ Merkle proof that validates this claim.
+     * @param getId_ Id to get the cumulative amount.
+     */
+    function claim(
+        uint256 cumulativeAmount_,
+        address fToken_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_,
+        uint256 getId_
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint256 _amt = getUint(getId_, cumulativeAmount_);
+
+        IFluidMerkleDistributor distributorContract_ = IFluidMerkleDistributor(MERKLE_DISTRIBUTOR);
+
+        distributorContract_.claim(address(this), _amt, fToken_, cycle_, merkleProof_);
+
+        _eventName = "LogClaim(uint256,address,uint256,bytes32[],uint256)";
+        _eventParam = abi.encode(_amt, fToken_, cycle_, merkleProof_, getId_);
+    }
+
+    /**
+     * @dev Claims rewards from Fluid merkle distributor contract
+     * @param cumulativeAmount_ Total reward cumulated since reward inception.
+     * @param fToken_ Address of fToken on which rewards are being distributed.
+     * @param cycle_ Current epoch cycle.
+     * @param merkleProof_ Merkle proof that validates this claim.
+     * @param getId_ Id to get the cumulative amount.
+    */
+    function claimOnBehalf(
+        address recipient_,
+        uint256 cumulativeAmount_,
+        address fToken_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_,
+        uint256 getId_
+    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
+        uint256 _amt = getUint(getId_, cumulativeAmount_);
+
+        IFluidMerkleDistributor distributorContract_ = IFluidMerkleDistributor(MERKLE_DISTRIBUTOR);
+
+        distributorContract_.claim(recipient_, _amt, fToken_, cycle_, merkleProof_);
+
+        _eventName = "LogClaimOnBehalf(address,uint256,address,uint256,bytes32[],uint256)";
+        _eventParam = abi.encode(recipient_, _amt, fToken_, cycle_, merkleProof_, getId_);
+    }
+}
+
+contract ConnectV2FluidMerkleClaim is FluidMerkle {
+    string public constant name = "Fluid-Merkle-v1.0";
+}


### PR DESCRIPTION
- Adds `claim` and `claimOnBehalf` to claim rewards through Fluid reward distributor contract.