### PR TITLE
feat: add arbitrum merkle claim connector for fluid

### DIFF
--- a/contracts/arbitrum/connectors/fluid-merkle-claim/events.sol
+++ b/contracts/arbitrum/connectors/fluid-merkle-claim/events.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.2;
 
 contract Events {
     event LogClaim(
+        address merkleDistributorContract,
+        address rewardToken,
         uint256 cumulativeAmount,
         bytes32 positionId,
         uint256 cycle,
@@ -12,11 +14,40 @@ contract Events {
     );
 
     event LogClaimOnBehalf(
+        address merkleDistributorContract,
+        address rewardToken,
         address recipient_,
         uint256 cumulativeAmount,
         bytes32 positionId,
         uint256 cycle,
         bytes32[] merkleProof,
+        uint256 rewardsClaimed,
+        uint256 setId
+    );
+
+    event LogClaimV2(
+        address merkleDistributorContract,
+        address rewardToken,
+        uint256 cumulativeAmount,
+        uint8 positonType,
+        bytes32 positionId,
+        uint256 cycle,
+        bytes32[] merkleProof,
+        bytes metadata,
+        uint256 rewardsClaimed,
+        uint256 setId
+    );
+
+    event LogClaimOnBehalfV2(
+        address merkleDistributorContract,
+        address rewardToken,
+        address recipient_,
+        uint256 cumulativeAmount,
+        uint8 positonType,
+        bytes32 positionId,
+        uint256 cycle,
+        bytes32[] merkleProof,
+        bytes metadata,
         uint256 rewardsClaimed,
         uint256 setId
     );

--- a/contracts/arbitrum/connectors/fluid-merkle-claim/interfaces.sol
+++ b/contracts/arbitrum/connectors/fluid-merkle-claim/interfaces.sol
@@ -10,3 +10,15 @@ interface IFluidMerkleDistributor {
         bytes32[] calldata merkleProof_
     ) external;
 }
+
+interface IFluidMerkleDistributorV2 {
+    function claim(
+        address recipient_,
+        uint256 cumulativeAmount_,
+        uint8 positionType_,
+        bytes32 positionId_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_,
+        bytes memory metadata_
+    ) external;
+}

--- a/contracts/arbitrum/connectors/fluid-merkle-claim/main.sol
+++ b/contracts/arbitrum/connectors/fluid-merkle-claim/main.sol
@@ -2,27 +2,30 @@
 pragma solidity ^0.8.2;
 
 import "./events.sol";
-import { Basic } from "../../common/basic.sol";
-import { IFluidMerkleDistributor } from "./interfaces.sol";
-import { TokenInterface } from "../../common/interfaces.sol";
+import {Basic} from "../../common/basic.sol";
+import {IFluidMerkleDistributor, IFluidMerkleDistributorV2} from "./interfaces.sol";
+import {TokenInterface} from "../../common/interfaces.sol";
 
 abstract contract FluidMerkleClaim is Basic, Events {
-
-    IFluidMerkleDistributor internal constant MERKLE_DISTRIBUTOR = 
-        IFluidMerkleDistributor(0x0c20EC658abA203c55665D8Dcb4e18304a08ebbd);
-
-    TokenInterface internal constant TOKEN =
-        TokenInterface(0x912CE59144191C1204E64559FE8253a0e49E6548);
-
     function claim(
+        address merkleDistributorContract,
+        address rewardToken,
         uint256 cumulativeAmount_,
         bytes32 positionId_,
         uint256 cycle_,
         bytes32[] calldata merkleProof_,
         uint256 setId_
-    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
-        uint256 rewardsBeforeBal_ = TOKEN.balanceOf(address(this));
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        TokenInterface REWARD_TOKEN = TokenInterface(rewardToken);
+        IFluidMerkleDistributor MERKLE_DISTRIBUTOR = IFluidMerkleDistributor(
+            merkleDistributorContract
+        );
 
+        uint256 rewardsBeforeBal_ = REWARD_TOKEN.balanceOf(address(this));
         MERKLE_DISTRIBUTOR.claim(
             address(this),
             cumulativeAmount_,
@@ -31,11 +34,14 @@ abstract contract FluidMerkleClaim is Basic, Events {
             merkleProof_
         );
 
-        uint256 rewardsClaimed_ = TOKEN.balanceOf(address(this)) - rewardsBeforeBal_;
+        uint256 rewardsClaimed_ = REWARD_TOKEN.balanceOf(address(this)) -
+            rewardsBeforeBal_;
         setUint(setId_, rewardsClaimed_);
 
-        _eventName = "LogClaim(uint256,bytes32,uint256,bytes32[],uint256,uint256)";
+        _eventName = "LogClaim(address,address,uint256,bytes32,uint256,bytes32[],uint256,uint256)";
         _eventParam = abi.encode(
+            merkleDistributorContract,
+            rewardToken,
             cumulativeAmount_,
             positionId_,
             cycle_,
@@ -46,15 +52,25 @@ abstract contract FluidMerkleClaim is Basic, Events {
     }
 
     function claimOnBehalf(
+        address merkleDistributorContract,
+        address rewardToken,
         address recipient_,
         uint256 cumulativeAmount_,
         bytes32 positionId_,
         uint256 cycle_,
         bytes32[] calldata merkleProof_,
         uint256 setId_
-    ) external payable returns (string memory _eventName, bytes memory _eventParam) {
-        uint256 rewardsBeforeBal_ = TOKEN.balanceOf(address(this));
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        TokenInterface REWARD_TOKEN = TokenInterface(rewardToken);
+        IFluidMerkleDistributor MERKLE_DISTRIBUTOR = IFluidMerkleDistributor(
+            merkleDistributorContract
+        );
 
+        uint256 rewardsBeforeBal_ = REWARD_TOKEN.balanceOf(address(this));
         MERKLE_DISTRIBUTOR.claim(
             recipient_,
             cumulativeAmount_,
@@ -63,11 +79,14 @@ abstract contract FluidMerkleClaim is Basic, Events {
             merkleProof_
         );
 
-        uint256 rewardsClaimed_ = TOKEN.balanceOf(address(this)) - rewardsBeforeBal_;
+        uint256 rewardsClaimed_ = REWARD_TOKEN.balanceOf(address(this)) -
+            rewardsBeforeBal_;
         setUint(setId_, rewardsClaimed_);
 
-        _eventName = "LogClaimOnBehalf(address,uint256,bytes32,uint256,bytes32[],uint256,uint256)";
+        _eventName = "LogClaimOnBehalf(address,address,uint256,bytes32,uint256,bytes32[],uint256,uint256)";
         _eventParam = abi.encode(
+            merkleDistributorContract,
+            rewardToken,
             recipient_,
             cumulativeAmount_,
             positionId_,
@@ -77,8 +96,113 @@ abstract contract FluidMerkleClaim is Basic, Events {
             setId_
         );
     }
+
+    function claimV2(
+        address merkleDistributorContract,
+        address rewardToken,
+        uint256 cumulativeAmount_,
+        uint8 positonType_,
+        bytes32 positionId_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_,
+        bytes memory metadata_,
+        uint256 setId_
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        TokenInterface REWARD_TOKEN = TokenInterface(rewardToken);
+        IFluidMerkleDistributorV2 MERKLE_DISTRIBUTOR = IFluidMerkleDistributorV2(
+                merkleDistributorContract
+            );
+
+        uint256 rewardsBeforeBal_ = REWARD_TOKEN.balanceOf(address(this));
+        MERKLE_DISTRIBUTOR.claim(
+            address(this),
+            cumulativeAmount_,
+            positonType_,
+            positionId_,
+            cycle_,
+            merkleProof_,
+            metadata_
+        );
+
+        uint256 rewardsClaimed_ = REWARD_TOKEN.balanceOf(address(this)) -
+            rewardsBeforeBal_;
+        setUint(setId_, rewardsClaimed_);
+
+        _eventName = "LogClaimV2(address,address,uint256,bytes32,uint256,bytes32[],uint256,uint256)";
+        _eventParam = abi.encode(
+            merkleDistributorContract,
+            rewardToken,
+            cumulativeAmount_,
+            positionId_,
+            cycle_,
+            merkleProof_,
+            rewardsClaimed_,
+            setId_
+        );
+    }
+
+    struct ClaimOnBehalfHelper{
+        uint256 rewardsBeforeBal_;
+        uint256 rewardsClaimed_;
+    }
+
+    function claimOnBehalfV2(
+        address merkleDistributorContract,
+        address rewardToken,
+        address recipient_,
+        uint256 cumulativeAmount_,
+        uint8 positonType_,
+        bytes32 positionId_,
+        uint256 cycle_,
+        bytes32[] calldata merkleProof_,
+        bytes memory metadata_,
+        uint256 setId_
+    )
+        external
+        payable
+        returns (string memory _eventName, bytes memory _eventParam)
+    {
+        TokenInterface REWARD_TOKEN = TokenInterface(rewardToken);
+        IFluidMerkleDistributorV2 MERKLE_DISTRIBUTOR = IFluidMerkleDistributorV2(
+                merkleDistributorContract
+            );
+
+        ClaimOnBehalfHelper memory helper_;
+
+        helper_.rewardsBeforeBal_ = REWARD_TOKEN.balanceOf(address(this));
+        MERKLE_DISTRIBUTOR.claim(
+            recipient_,
+            cumulativeAmount_,
+            positonType_,
+            positionId_,
+            cycle_,
+            merkleProof_,
+            metadata_
+        );
+
+        helper_.rewardsClaimed_ = REWARD_TOKEN.balanceOf(address(this)) -
+            helper_.rewardsBeforeBal_;
+        setUint(setId_, helper_.rewardsClaimed_);
+
+        _eventName = "LogClaimOnBehalfV2(address,address,uint256,bytes32,uint256,bytes32[],uint256,uint256)";
+        _eventParam = abi.encode(
+            merkleDistributorContract,
+            rewardToken,
+            recipient_,
+            cumulativeAmount_,
+            positionId_,
+            cycle_,
+            merkleProof_,
+            helper_.rewardsClaimed_,
+            setId_
+        );
+    }
 }
 
 contract ConnectV2FluidMerkleClaimArbitrum is FluidMerkleClaim {
-    string public constant name = "Fluid-Merkle-v1.0";
+    string public constant name = "Fluid-Merkle-Claim-v1.1";
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -175,7 +175,7 @@ const config: any = {
       mainnet: String(process.env.ETHERSCAN_V2_API_KEY),
       optimisticEthereum: String(process.env.ETHERSCAN_V2_API_KEY),
       polygon: String(process.env.ETHERSCAN_V2_API_KEY),
-      arbitrumOne: String(process.env.ETHERSCAN_V2_API_KEY),
+      arbitrum: String(process.env.ETHERSCAN_V2_API_KEY),
       avalanche: String(process.env.AVAX_ETHSCAN_KEY),
       opera: String(process.env.FTM_ETHSCAN_KEY),
       base: String(process.env.BASE_ETHSCAN_KEY),
@@ -221,6 +221,14 @@ const config: any = {
         urls: {
           apiURL: "https://api.etherscan.io/v2/api?chainid=56",
           browserURL: "https://bscscan.com"
+        }
+      },
+      {
+        network: "arbitrum",
+        chainId: 42161,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=42161",
+          browserURL: "https://arbiscan.io"
         }
       }
     ]

--- a/scripts/deployment/verify.ts
+++ b/scripts/deployment/verify.ts
@@ -1,7 +1,7 @@
 import hre, { ethers } from "hardhat";
 
 async function main() {
-  const address = "0x4C687263C79Ca45915EBe6d79defeedc6569CDAf";
+  const address = "0xD41ac7C73fe8A0a1D6F11fC43aE4E0661b8B5C87";
   const chain = String(hre.network.name);
   if (chain !== "hardhat") {
     await hre.run("verify:verify", {


### PR DESCRIPTION
`FLUID-MERKLE-CLAIM-A` : [0x56E001745F105E34aFE45398D7bc366db8FC5792](https://arbiscan.io/address/0x56E001745F105E34aFE45398D7bc366db8FC5792#code)